### PR TITLE
Add Vue and Nuxt docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,47 @@ export default function App() {
 
 Learn more at [tldraw.dev](https://tldraw.dev).
 
+## Vue & Nuxt
+
+Use the Vue bindings to integrate the editor in Vue or Nuxt3 projects. This
+package is not yet published on npm, so install it directly from GitHub.
+
+### Installation
+
+```bash
+npm install git+https://github.com/<your-user>/<your-repo>.git#packages/tldraw-vue \
+  tldraw react react-dom
+```
+Replace `<your-user>/<your-repo>` with the GitHub repository hosting the Vue bindings.
+
+### Usage
+
+```vue
+<script setup lang="ts">
+import { TldrawVue } from '@tldraw/vue'
+import 'tldraw/tldraw.css'
+</script>
+
+<template>
+  <TldrawVue />
+</template>
+```
+
+### Nuxt plugin
+
+Register the component globally in Nuxt via a plugin:
+
+```ts
+// plugins/tldraw.client.ts
+import { defineNuxtPlugin } from '#app'
+import { TldrawVue } from '@tldraw/vue'
+import 'tldraw/tldraw.css'
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.component('TldrawVue', TldrawVue)
+})
+```
+
 ## Local development
 
 The local development server will run our examples app. The basic example will show any changes you've made to the codebase.

--- a/apps/docs/content/frameworks/vue.mdx
+++ b/apps/docs/content/frameworks/vue.mdx
@@ -11,15 +11,17 @@ keywords:
   - tldraw
 ---
 
-Use `@tldraw/vue` to integrate the tldraw editor in Vue and Nuxt applications.
+Use the `@tldraw/vue` bindings to integrate the tldraw editor in Vue and Nuxt applications.
 
 ## Installation
 
-Install the package along with `tldraw` and its peer dependencies:
+Install the bindings along with `tldraw` and its peer dependencies. Since the package is not published on npm, install it from GitHub:
 
 ```bash
-npm install @tldraw/vue tldraw react react-dom
+npm install git+https://github.com/<your-user>/<your-repo>.git#packages/tldraw-vue \
+  tldraw react react-dom
 ```
+Replace `<your-user>/<your-repo>` with the repository hosting the Vue bindings.
 
 ## Usage
 

--- a/packages/tldraw-vue/README.md
+++ b/packages/tldraw-vue/README.md
@@ -5,7 +5,7 @@ Vue bindings for the tldraw editor. This package exposes a `<TldrawVue>` compone
 ## Installation
 
 ```bash
-npm install @tldraw/vue
+npm install git+https://github.com/<your-user>/<your-repo>.git#packages/tldraw-vue
 ```
 
 Make sure you also install `tldraw` and its peer dependencies `react` and `react-dom`.


### PR DESCRIPTION
## Summary
- document Vue and Nuxt usage in the main README
- describe installing the Vue bindings from GitHub in docs

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848781befd883238c5c69abf005d47f